### PR TITLE
Enable keyboard toggle for login password

### DIFF
--- a/Views/Acceso/Login.cshtml
+++ b/Views/Acceso/Login.cshtml
@@ -579,7 +579,12 @@
                                             <span class="input-group-text"><i class="bi bi-lock"></i></span>
                                             <input type="password" class="form-control" id="claveInput" name="Clave"
                                                 placeholder="••••••••" required />
-                                            <span class="input-group-text" onclick="togglePassword()">
+                                            <span class="input-group-text"
+                                                role="button"
+                                                tabindex="0"
+                                                aria-label="Mostrar u ocultar contraseña"
+                                                onclick="togglePassword()"
+                                                onkeydown="togglePassword(event)">
                                                 <i class="bi bi-eye" id="iconoClave"></i>
                                             </span>
                                         </div>
@@ -800,7 +805,11 @@
         });
 
         // Toggle password visibility
-        function togglePassword() {
+        function togglePassword(event) {
+            if (event && event.type === 'keydown' && !(event.key === 'Enter' || event.key === ' ')) {
+                return;
+            }
+
             const input = document.getElementById("claveInput");
             const icon = document.getElementById("iconoClave");
             if (input.type === "password") {


### PR DESCRIPTION
## Summary
- add accessibility attributes to the password visibility span
- update `togglePassword` to handle `keydown` events for Enter and space

## Testing
- `dotnet build MEXIGEO.sln -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685223601a84832fae24ac1397090ba4